### PR TITLE
Change HTTP request method due to incompatibility in newer Chrome releases

### DIFF
--- a/api/controllers/printPdfController.js
+++ b/api/controllers/printPdfController.js
@@ -73,7 +73,7 @@ async function load(html) {
             console.log(`Load using ports ${options.port}`);
         }
 
-        target = await CDP.New({port: options.port});
+        target = await CDP.New({port: options.port, method: 'PUT'});
         const client = await CDP({target});
         const {Network, Page} = client;
         await Promise.all([Network.enable(), Page.enable()]);

--- a/api/controllers/printPngController.js
+++ b/api/controllers/printPngController.js
@@ -30,7 +30,7 @@ async function load(html) {
             console.log(`Load using ports ${options.port}`);
         }
 
-        target = await CDP.New({port: options.port});
+        target = await CDP.New({port: options.port, method: 'PUT'});
         const client = await CDP({target});
         const {Network, Page} = client;
         await Promise.all([Network.enable(), Page.enable()]);


### PR DESCRIPTION

See: https://danielcompton.net/snippets/chrome-devtools-unsafe-http-verb